### PR TITLE
fix(accessibility): add missing alt property to img

### DIFF
--- a/_data/download.yml
+++ b/_data/download.yml
@@ -1,17 +1,17 @@
 ---
 url-ready:
-  label: <a class="newicon" href="https://mega.nz/file/lDgWERZQ#VRN3BRdJ0RYYf0bQN8Q-hXlwsviXmlQBrwl_hHKuTxQ" target="_blank"><img src="assets/down.png" width="30" height="30"></a>
+  label: <a class="newicon" href="https://mega.nz/file/lDgWERZQ#VRN3BRdJ0RYYf0bQN8Q-hXlwsviXmlQBrwl_hHKuTxQ" target="_blank"><img src="assets/down.png" alt="Download logo" width="30" height="30"></a>
 url-hat:
-  label: <a class="newicon" href="https://mega.nz/file/1WAkERSY#e8Uuy7P26pLmsoTf2ImQQ9Y9JQBUytmw0PSOTGm4vzk" target="_blank"><img src="assets/down.png" width="30" height="30"></a>
+  label: <a class="newicon" href="https://mega.nz/file/1WAkERSY#e8Uuy7P26pLmsoTf2ImQQ9Y9JQBUytmw0PSOTGm4vzk" target="_blank"><img src="assets/down.png" alt="Download logo" width="30" height="30"></a>
 url-serve:
-  label: <a class="newicon" href="https://mega.nz/file/EeB1lCQC#IcApvSJtNz0_ZWahab31gUCcqTkuua6al5V3EVqLRDM" target="_blank"><img src="assets/down.png" width="30" height="30"></a>
+  label: <a class="newicon" href="https://mega.nz/file/EeB1lCQC#IcApvSJtNz0_ZWahab31gUCcqTkuua6al5V3EVqLRDM" target="_blank"><img src="assets/down.png" alt="Download logo" width="30" height="30"></a>
 url-brain:
-  label: <a class="newicon" href="https://mega.nz/file/VaoEAIQZ#KZn0xXn72DeFOw-Uhny90F_oMdk45ZfbloPK0OJ5nbI" target="_blank"><img src="assets/down.png" width="30" height="30"></a>
+  label: <a class="newicon" href="https://mega.nz/file/VaoEAIQZ#KZn0xXn72DeFOw-Uhny90F_oMdk45ZfbloPK0OJ5nbI" target="_blank"><img src="assets/down.png" alt="Download logo" width="30" height="30"></a>
 url-responder:
-  label: <a class="newicon" href="https://mega.nz/file/RS5TEKTQ#gBlcqKNFXM5-hjVxmfhv2WannUuQ58pyxN3xRxRBqkE" target="_blank"><img src="assets/down.png" width="30" height="30"></a>
+  label: <a class="newicon" href="https://mega.nz/file/RS5TEKTQ#gBlcqKNFXM5-hjVxmfhv2WannUuQ58pyxN3xRxRBqkE" target="_blank"><img src="assets/down.png" alt="Download logo" width="30" height="30"></a>
 url-wrapp:
-  label: <a class="newicon" href="https://mega.nz/file/AC5VEIzL#2hOxKm4WlpstvVn4wu-tXwG7xlZFQvspg3_QduqyWtg" target="_blank"><img src="assets/down.png" width="30" height="30"></a>
+  label: <a class="newicon" href="https://mega.nz/file/AC5VEIzL#2hOxKm4WlpstvVn4wu-tXwG7xlZFQvspg3_QduqyWtg" target="_blank"><img src="assets/down.png" alt="Download logo" width="30" height="30"></a>
 url-doctor:
-  label: <a class="newicon" href="https://mega.nz/file/5PwRnKTZ#OVbmj6rTjn1u5r3nY21hFALD0MiMnyiRMHPgs20Xf8E" target="_blank"><img src="assets/down.png" width="30" height="30"></a>
+  label: <a class="newicon" href="https://mega.nz/file/5PwRnKTZ#OVbmj6rTjn1u5r3nY21hFALD0MiMnyiRMHPgs20Xf8E" target="_blank"><img src="assets/down.png" alt="Download logo" width="30" height="30"></a>
 url-secrets:
-  label: <a class="newicon" href="https://mega.nz/file/VCQgWRIL#3__3csvkBgMqYdeNkqniPZIQTUwHYcg0Wy9kvw9lJ_Q" target="_blank"><img src="assets/down.png" width="30" height="30"></a>
+  label: <a class="newicon" href="https://mega.nz/file/VCQgWRIL#3__3csvkBgMqYdeNkqniPZIQTUwHYcg0Wy9kvw9lJ_Q" target="_blank"><img src="assets/down.png" alt="Download logo" width="30" height="30"></a>

--- a/_data/tested.yml
+++ b/_data/tested.yml
@@ -1,3 +1,3 @@
 --- 
 VirtualBox: 
-  label: <img title="VirtualBox" src="assets/virtualbox.png" width="30" height="30">
+  label: <img title="VirtualBox" alt="VirtualBox logo" src="assets/virtualbox.png" width="30" height="30">


### PR DESCRIPTION
Following accessibility principles, alt is a necessary attribute in the img tag as it helps screen readers.