### PR TITLE
fix: revert creator url

### DIFF
--- a/_data/creator.yml
+++ b/_data/creator.yml
@@ -1,5 +1,6 @@
 ---
 d4t4s3c:
   label: d4t4s3c
+  url: https://github.com/d4t4s3c
 mowree:
   label: mowree

--- a/_includes/creator_list.html
+++ b/_includes/creator_list.html
@@ -3,6 +3,10 @@
     {% assign platf_id = platf_pair[0] %}
     {% assign platf = platf_pair[1] %}
     {% unless include.bin.creator[platf_id] %}{% continue %}{% endunless %}
-    <a>{{ platf.label }}</a>
+        {% if platf.url %}
+            <a href="{{ platf.url }}" target="_blank">{{ platf.label }}</a>
+        {% else %}
+            <span>{{ platf.label }}</span>
+        {% endif %}
     {% endfor %}
 </div>


### PR DESCRIPTION
Using a condition that checks if the creator has the url parameter. 
If not display the name in plain text.