### PR TITLE
feat: custom rule to prevent kramdown wrapping standalone <img> and <a> with a <p>

### DIFF
--- a/_plugins/kramdown-parsing.rb
+++ b/_plugins/kramdown-parsing.rb
@@ -1,0 +1,10 @@
+require 'kramdown/converter/html'
+
+module StandaloneImagesAndLinks
+  def convert_p(el, indent)
+    return super unless el.children.size == 1 && ((el.children.first.type == :img || (el.children.first.type == :html_element && el.children.first.value == "img")) || (el.children.first.type == :a || (el.children.first.type == :html_element && el.children.first.value == "a")))
+    convert(el.children.first, indent)
+  end
+end
+
+Kramdown::Converter::Html.prepend StandaloneImagesAndLinks

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -73,7 +73,7 @@ p + ol li {
   padding: 0.25rem 0;
 }
 
-#vvm-state a {
+#vm-state a {
   background: $red;
   font-weight: bold;
   border-radius: 0.25em;

--- a/index.md
+++ b/index.md
@@ -3,9 +3,9 @@ layout: page
 title: VulNyx
 ---
 
-![logo](/assets/logo.png){:.logo}
+![VulNyx website logo](/assets/logo.png){:.logo}
 
-<div id="vvm-state">
+<div id="vm-state">
 <b>VulNyx</b> is a website that contains a <b>list</b> of <b>vulnerable machines</b> that are <b>Unix</b> based. These machines have security flaws and have different <b>difficulty</b> levels. Here you can <b>learn</b> & <b>practice</b> your <b>security</b> skills.
 <br>
 <br>


### PR DESCRIPTION
Also improve the logo alt property and fix a typo on a css class.